### PR TITLE
Check if IAnnotations provided context to get ignored symptoms.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ log.html
 output.xml
 report.html
 .DS_Store*
+pip-selfcheck.json

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changelog
 0.3.1 (unreleased)
 ------------------
 
+- Check if IAnnotations provided context to get ignored symptoms.
+  It will prevent an error when context is IItem (no Archetypes or Dexterity).
+  [bsuttor]
+
 - Do not override view_methods of collection on installation.
   [bsuttor]
 

--- a/src/collective/jekyll/ignored.py
+++ b/src/collective/jekyll/ignored.py
@@ -1,8 +1,8 @@
-from persistent.dict import PersistentDict
-from zope.interface import implements
-from zope.annotation.interfaces import IAnnotations
-
+# -*- coding: utf-8 -*-
 from collective.jekyll.interfaces import IIgnoredSymptomNames
+from persistent.dict import PersistentDict
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import implements
 
 
 JEKYLL_IGNORED_SYMPTOMS = 'JEKYLL_IGNORED_SYMPTOMS'
@@ -15,6 +15,8 @@ class IgnoredNames(object):
         self.context = context
 
     def _getNamesDict(self):
+        if not IAnnotations.providedBy(self.context):
+            return {}
         annotations = IAnnotations(self.context)
         return annotations.setdefault(
             JEKYLL_IGNORED_SYMPTOMS, PersistentDict())

--- a/travis.cfg
+++ b/travis.cfg
@@ -3,7 +3,7 @@ extends =
     https://raw.github.com/collective/buildout.plonetest/master/travis-4.3.x.cfg
     buildout-varnish.cfg
     coverage.cfg
-    http://dist.plone.org/release/4.3.1/versions.cfg
+    http://dist.plone.org/release/4.3.15/versions.cfg
 
 package-name = collective.jekyll
 package-extras = [test]


### PR DESCRIPTION
It will prevent an error when context is IItem (not Archetypes or Dexterity).
I have errors with old Products.PloneGazette pacakge.